### PR TITLE
Fix #8 - Add fill byte in writeItems

### DIFF
--- a/src/s7endpoint.js
+++ b/src/s7endpoint.js
@@ -180,16 +180,15 @@ class S7Endpoint extends EventEmitter {
             new Promise((res, rej) => setTimeout(() => rej(new NodeS7Error('ERR_TIMEOUT', 'Timeout connecting to the transport')), 10000).unref())
         ]);
 
-        race.then(transport => {
-            this._transport = transport;
+        race.then((transport) => {
             this._transport.on('error', e => this._onTransportError(e));
             this._transport.on('close', () => this._onTransportClose());
             this._transport.on('end', () => this._onTransportEnd());
             this._createS7Connection();
             this._connection.connect();
-        }).catch(e => this._onTransportError(e));
+        }).catch((e) => this._onTransportError(e));
     }
-
+ 
     /**
      * Creates an ISO-on-TCP transport with the parameters
      * supplied on the constructor
@@ -203,11 +202,11 @@ class S7Endpoint extends EventEmitter {
             // handler to reject the promise on connection-time errors
             const handleRejection = e => reject(e);
 
-            let stream = isoOnTcp.createConnection(this._connOptsTcp, () => {
-                stream.off('error', handleRejection);
-                resolve(stream);
+            this._transport = isoOnTcp.createConnection(this._connOptsTcp, () => {
+                this._transport.off("error", handleRejection);
+                resolve(this._transport);
             });
-            stream.on('error', handleRejection);
+            this._transport.on('error', handleRejection);
         })
     }
 

--- a/src/s7endpoint.js
+++ b/src/s7endpoint.js
@@ -186,7 +186,7 @@ class S7Endpoint extends EventEmitter {
             this._transport.on('end', () => this._onTransportEnd());
             this._createS7Connection();
             this._connection.connect();
-        }).catch((e) => this._onTransportError(e));
+        }).catch(e => this._onTransportError(e));
     }
  
     /**
@@ -203,7 +203,7 @@ class S7Endpoint extends EventEmitter {
             const handleRejection = e => reject(e);
 
             this._transport = isoOnTcp.createConnection(this._connOptsTcp, () => {
-                this._transport.off("error", handleRejection);
+                this._transport.off('error', handleRejection);
                 resolve(this._transport);
             });
             this._transport.on('error', handleRejection);

--- a/src/s7itemGroup.js
+++ b/src/s7itemGroup.js
@@ -479,7 +479,7 @@ class S7ItemGroup extends EventEmitter {
             }
 
             let buf = item.getWriteBuffer(value);
-            let reqItemLength = overheadPerItem + buf.length;
+            let reqItemLength = overheadPerItem + item.byteLengthWithFill
 
             // TODO - maybe we can split an item in multiple write request parts
             if (reqItemLength > maxPayloadSize) {

--- a/src/s7itemGroup.js
+++ b/src/s7itemGroup.js
@@ -479,7 +479,7 @@ class S7ItemGroup extends EventEmitter {
             }
 
             let buf = item.getWriteBuffer(value);
-            let reqItemLength = overheadPerItem + item.byteLengthWithFill
+            let reqItemLength = overheadPerItem + item.byteLengthWithFill;
 
             // TODO - maybe we can split an item in multiple write request parts
             if (reqItemLength > maxPayloadSize) {


### PR DESCRIPTION
This should solve the issue. 
I did some tests and I was able to write more than 40 boolean variables simultaneously.
It still works well while writing integer and real data.